### PR TITLE
fix: repair .secrets.baseline (stray uv line breaks detect-secrets hook)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,4 +1,3 @@
-Installed 7 packages in 5ms
 {
   "version": "1.5.0",
   "plugins_used": [


### PR DESCRIPTION
## Problem

`.secrets.baseline` has a stray first line — `Installed 7 packages in 5ms` — captured from `uv` when the baseline was generated via a redirect (`uv run detect-secrets scan > .secrets.baseline`). That makes the file invalid JSON, so `detect-secrets` fails with **"Unable to read baseline"** and the `detect-secrets` pre-commit hook errors on every run. Anyone who runs `pre-commit install` then can't commit (without `--no-verify`).

## Fix

Remove the spurious first line. The remainder is a valid v1.5.0 baseline (`results: {}`). One-line deletion.

## Verification

```
$ python3 -c "import json; json.load(open('.secrets.baseline'))"   # valid
$ pre-commit run --all-files
...
Detect secrets...........................................................Passed
```
The commit on this branch ran through the hook itself — detect-secrets passed.