### PR TITLE
Fix /track-ws 404: install a WebSocket backend (websockets)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,13 @@ classifiers = [
 dependencies = [
     "fastapi>=0.136,<1",
     "uvicorn>=0.32,<1",
+    # The /track-ws endpoint needs a WebSocket protocol backend at runtime.
+    # Bare `uvicorn` ships none (it lives in the `[standard]` extra), so under
+    # gunicorn's UvicornWorker every upgrade 404s with "No supported WebSocket
+    # library detected". Depend on `websockets` directly — lighter than the
+    # full `[standard]` extra (no uvloop/httptools/watchfiles) and all the
+    # worker actually needs to accept the upgrade.
+    "websockets>=14,<17",
     "gunicorn>=23.0,<24",
     "httpx>=0.28,<1",
     "tenacity>=9.0,<10",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -196,3 +196,22 @@ async def test_allowlist_rejects_unparseable_ip() -> None:
     assert starts and starts[0]["status"] == 403
     # App was never called because the middleware short-circuited.
     assert ("app", GATED_PATH) not in received
+
+
+def test_uvicorn_has_websocket_backend() -> None:
+    """Guard the /track-ws upgrade against a missing WebSocket backend.
+
+    Under gunicorn's ``UvicornWorker`` the WebSocket upgrade only works if a
+    protocol library (``websockets`` or ``wsproto``) is installed. Bare
+    ``uvicorn`` ships neither — they live in the ``uvicorn[standard]`` extra —
+    so without an explicit dependency the env builds fine, tests pass via
+    Starlette's in-process TestClient, and yet every live ``/track-ws`` 404s
+    with "No supported WebSocket library detected". This asserts the backend
+    is present so that regression can't ship silently again.
+    """
+    import importlib.util
+
+    assert importlib.util.find_spec("websockets") or importlib.util.find_spec("wsproto"), (
+        "no WebSocket backend (websockets/wsproto) installed — /track-ws will 404 "
+        "under uvicorn; add `websockets` to project dependencies"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -642,6 +642,7 @@ dependencies = [
     { name = "tenacity" },
     { name = "uvicorn" },
     { name = "weasyprint" },
+    { name = "websockets" },
 ]
 
 [package.dev-dependencies]
@@ -673,6 +674,7 @@ requires-dist = [
     { name = "tenacity", specifier = ">=9.0,<10" },
     { name = "uvicorn", specifier = ">=0.32,<1" },
     { name = "weasyprint", specifier = ">=63.0,<67" },
+    { name = "websockets", specifier = ">=14,<17" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Bug

Live letter tracking never worked in the deployed service. Every `/track-ws` WebSocket upgrade returns **404** with this in the gunicorn log:

```
[WARNING] No supported WebSocket library detected. ... install 'websockets' or 'wsproto'
"GET /track-ws HTTP/1.1" 404
[WARNING] Unsupported upgrade request.
```

## Root cause

`uvicorn` is declared **without the `[standard]` extra**, so the uv2nix-built env contains no WebSocket protocol library (`websockets`/`wsproto`). `websockets` appears in `uv.lock` only as uvicorn's *unselected* extra, so it's never installed. Under gunicorn's `UvicornWorker`, the upgrade can't be handled → 404 for **every** serial.

This slipped through because the test suite uses Starlette's `TestClient`, which performs WebSockets in-process and does **not** exercise uvicorn's protocol backend.

## Fix

- Add `websockets>=14,<17` as a direct dependency (lighter than the full `uvicorn[standard]` extra — no uvloop/httptools/watchfiles — and all the worker needs to accept the upgrade), and re-lock.
- Add `test_uvicorn_has_websocket_backend` asserting a ws backend is importable, so this regression can't ship silently again.

## Checks

- Full suite **288 passed** (incl. the new guard).
- `checks.lint` (ruff) + `checks.typecheck` (mypy) clean.